### PR TITLE
Add support for generating a Nais deployment key when adding teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @navikt/aura
+* @christeredvartsen

--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ The reason for using a personal access token instead of the auto-generated `GITH
 ### `TEAMS_YAML_PATH`
 
 Path to where the teams YAML file is located. Documentation regarding this file is available in the [navikt/teams](https://github.com/navikt/teams) repository.
+
+### `NAIS_DEPLOYMENT_API_SECRET`
+
+Hex-encoded secret used to create Nais deployment key for the teams.

--- a/action.php
+++ b/action.php
@@ -38,7 +38,7 @@ try {
         return $team['name'];
     }, Yaml::parseFile(getenv('TEAMS_YAML_PATH'))['teams']);
 } catch (ParseException $e) {
-    fail(sprintf('Invalid YAML in teams.yml: $s', $e->getMessage()));
+    fail(sprintf('Invalid YAML in teams.yml: %s', $e->getMessage()));
 }
 
 if (empty($teams)) {
@@ -134,7 +134,7 @@ foreach ($teams as $teamName) {
     try {
         $githubApiClient->syncTeamAndGroup($gihubTeam, $aadGroup);
     } catch (ClientException $e) {
-        fail(sprintf('Unable to sync GitHub team and Azure AD group. Error message: %s', $teamName, $e->getMessage()));
+        fail(sprintf('Unable to sync GitHub team and Azure AD group. Error message: %s', $e->getMessage()));
     }
 
     debug('Connected GitHub team with Azure AD group');
@@ -142,7 +142,7 @@ foreach ($teams as $teamName) {
     try {
         $naisDeploymentApiClient->provisionTeamKey($teamName);
     } catch (ClientException $e) {
-        fail(sprintf('Unable to create Nais deployment key. Error message: %s', $teamName, $e->getMessage()));
+        fail(sprintf('Unable to create Nais deployment key. Error message: %s', $e->getMessage()));
     }
 
     debug('Nais deployment key created');

--- a/action.php
+++ b/action.php
@@ -24,6 +24,7 @@ $requiredEnvVars = [
     'GITHUB_ACTOR',
     'GITHUB_PAT',
     'TEAMS_YAML_PATH',
+    'NAIS_DEPLOYMENT_API_SECRET'
 ];
 
 foreach ($requiredEnvVars as $requiredEnvVar) {
@@ -57,11 +58,15 @@ try {
         getenv('AZURE_AD_APP_SECRET')
     );
 } catch (ClientException $e) {
-    fail(sprintf('Could not create Azure API client: %s', $e->getMessage()));
+    fail(sprintf('Unable to create Azure API client: %s', $e->getMessage()));
 }
 
 $githubApiClient = new GitHubApiClient(
     getenv('GITHUB_PAT')
+);
+
+$naisDeploymentApiClient = new NaisDeploymentApiClient(
+    getenv('NAIS_DEPLOYMENT_API_SECRET')
 );
 
 $actor = getenv('GITHUB_ACTOR');
@@ -133,4 +138,12 @@ foreach ($teams as $teamName) {
     }
 
     debug('Connected GitHub team with Azure AD group');
+
+    try {
+        $naisDeploymentApiClient->provisionTeamKey($teamName);
+    } catch (ClientException $e) {
+        fail(sprintf('Unable to create Nais deployment key. Error message: %s', $teamName, $e->getMessage()));
+    }
+
+    debug('Nais deployment key created');
 }

--- a/src/NaisDeploymentApiClient.php
+++ b/src/NaisDeploymentApiClient.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+namespace NAV\Teams;
+
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+
+class NaisDeploymentApiClient {
+    /**
+     * Name of the middleware for the signature generation
+     *
+     * @var string
+     */
+    const ADD_SIGNATURE_MIDDLEWARE = 'add-signature';
+
+    /**
+     * HTTP Client instance
+     *
+     * @var HttpClient
+     */
+    private $httpClient;
+
+    /**
+     * Class constructor
+     *
+     * The constructor will add a handler for the HTTP client that handles signature generation
+     *
+     * @param string $secret Hex-encoded secret
+     * @param HttpClient $httpClient Pre-configured HTTP client instance
+     */
+    public function __construct(string $secret, HttpClient $httpClient = null) {
+        if (null === $httpClient) {
+            $httpClient = new HttpClient([
+                'base_uri' => 'https://deployment.prod-sbs.nais.io/api/v1/',
+            ]);
+        }
+
+        $httpClient
+            ->getConfig('handler')
+            ->unshift(Middleware::mapRequest(function(Request $request) use ($secret) : Request {
+                return $request->withHeader(
+                    'x-nais-signature',
+                    hash_hmac(
+                        'sha256',
+                        $request->getBody()->getContents(),
+                        hex2bin($secret)
+                    )
+                );
+            }), self::ADD_SIGNATURE_MIDDLEWARE);
+
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * Provision a team key
+     *
+     * @param string $team The name of the team
+     * @return bool
+     */
+    public function provisionTeamKey(string $team) : bool {
+        try {
+            $this->httpClient->post('provision', [
+                'json' => [
+                    'team'      => $team,
+                    'rotate'    => false,
+                    'timestamp' => time(),
+                ]]
+            );
+        } catch (ClientException $e) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/NaisDeploymentApiClient.php
+++ b/src/NaisDeploymentApiClient.php
@@ -44,7 +44,7 @@ class NaisDeploymentApiClient {
                     hash_hmac(
                         'sha256',
                         $request->getBody()->getContents(),
-                        hex2bin($secret)
+                        (string) hex2bin($secret)
                     )
                 );
             }), self::ADD_SIGNATURE_MIDDLEWARE);

--- a/src/NaisDeploymentApiClient.php
+++ b/src/NaisDeploymentApiClient.php
@@ -56,21 +56,15 @@ class NaisDeploymentApiClient {
      * Provision a team key
      *
      * @param string $team The name of the team
-     * @return bool
+     * @return void
      */
-    public function provisionTeamKey(string $team) : bool {
-        try {
-            $this->httpClient->post('provision', [
-                'json' => [
-                    'team'      => $team,
-                    'rotate'    => false,
-                    'timestamp' => time(),
-                ]]
-            );
-        } catch (ClientException $e) {
-            return false;
-        }
-
-        return true;
+    public function provisionTeamKey(string $team) : void {
+        $this->httpClient->post('provision', [
+            'json' => [
+                'team'      => $team,
+                'rotate'    => false,
+                'timestamp' => time(),
+            ]]
+        );
     }
 }

--- a/tests/GitHubApiClientTest.php
+++ b/tests/GitHubApiClientTest.php
@@ -15,7 +15,7 @@ use NAV\Teams\Models\AzureAdGroup;
 /**
  * @coversDefaultClass NAV\Teams\GitHubApiClient
  */
-class GitHubClientTest extends TestCase {
+class GitHubApiClientTest extends TestCase {
     private function getMockClient(array $responses, array &$history = []) : HttpClient {
         $handler = HandlerStack::create(new MockHandler($responses));
         $handler->push(Middleware::history($history));

--- a/tests/NaisDeploymentApiClientTest.php
+++ b/tests/NaisDeploymentApiClientTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+namespace NAV\Teams;
+
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Middleware;
+
+/**
+ * @coversDefaultClass NAV\Teams\NaisDeploymentApiClient
+ */
+class NaisDeploymentApiClientTest extends TestCase {
+    /**
+     * Get a mock Guzzle Client with a history middleware
+     *
+     * @param Response[] $responses A list of responses to return
+     * @param array $history Container for the history
+     * @return HttpClient
+     */
+    private function getMockClient(array $responses, array &$history = []) : HttpClient {
+        $handler = HandlerStack::create(new MockHandler($responses));
+        $handler->push(Middleware::history($history));
+
+        return new HttpClient(['handler' => $handler]);
+    }
+
+    /**
+     * @covers ::provisionTeamKey
+     */
+    public function testCanProvisionTeamKey() : void {
+        $history = [];
+        $httpClient = $this->getMockClient([new Response(201)], $history);
+        $this->assertTrue((new NaisDeploymentApiClient('736563726574', $httpClient))->provisionTeamKey('my-team'));
+        $this->assertNotEmpty($history[0]['request']->getHeaderLine('x-nais-signature'));
+    }
+
+    /**
+     * @covers ::provisionTeamKey
+     */
+    public function testReturnsFalseWhenKeyProvisioningFails() : void {
+        $httpClient = $this->getMockClient([new Response(403)]);
+        $this->assertFalse((new NaisDeploymentApiClient('736563726574', $httpClient))->provisionTeamKey('my-team'));
+    }
+}

--- a/tests/NaisDeploymentApiClientTest.php
+++ b/tests/NaisDeploymentApiClientTest.php
@@ -3,6 +3,7 @@ namespace NAV\Teams;
 
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
@@ -32,7 +33,7 @@ class NaisDeploymentApiClientTest extends TestCase {
     public function testCanProvisionTeamKey() : void {
         $history = [];
         $httpClient = $this->getMockClient([new Response(201)], $history);
-        $this->assertTrue((new NaisDeploymentApiClient('736563726574', $httpClient))->provisionTeamKey('my-team'));
+        (new NaisDeploymentApiClient('736563726574', $httpClient))->provisionTeamKey('my-team');
         $this->assertNotEmpty($history[0]['request']->getHeaderLine('x-nais-signature'));
     }
 
@@ -41,6 +42,7 @@ class NaisDeploymentApiClientTest extends TestCase {
      */
     public function testReturnsFalseWhenKeyProvisioningFails() : void {
         $httpClient = $this->getMockClient([new Response(403)]);
-        $this->assertFalse((new NaisDeploymentApiClient('736563726574', $httpClient))->provisionTeamKey('my-team'));
+        $this->expectException(ClientException::class);
+        (new NaisDeploymentApiClient('736563726574', $httpClient))->provisionTeamKey('my-team');
     }
 }


### PR DESCRIPTION
This PR introduces a Nais Deployment API client used to provision a team secret.

Resolves #7.