### PR TITLE
Handle description

### DIFF
--- a/action.php
+++ b/action.php
@@ -48,8 +48,12 @@ if (empty($teams)) {
 }
 
 foreach ($teams as $team) {
-    if (0 === preg_match('/^[a-z][a-z0-9-]{3,29}(?<!-)$/', $team)) {
-        fail(sprintf('Invalid team name: %s', $team));
+    if (empty($team['name'])) {
+        fail(sprintf('Missing team name: %s', Yaml::dump($team)));
+    } else if (empty($team['description'])) {
+        fail(sprintf('Missing team description: %s', Yaml::dump($team)));
+    } else if (0 === preg_match('/^[a-z][a-z0-9-]{3,29}(?<!-)$/', $team['name'])) {
+        fail(sprintf('Invalid team name: %s', $team['name']));
     }
 }
 

--- a/action.php
+++ b/action.php
@@ -2,6 +2,7 @@
 namespace NAV\Teams;
 
 use NAV\Teams\Runner\ResultPrinter;
+use NAV\Teams\Exceptions\InvalidArgumentException;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 use GuzzleHttp\Exception\ClientException;
@@ -47,16 +48,6 @@ if (empty($teams)) {
     exit;
 }
 
-foreach ($teams as $team) {
-    if (empty($team['name'])) {
-        fail(sprintf('Missing team name: %s', Yaml::dump($team)));
-    } else if (empty($team['description'])) {
-        fail(sprintf('Missing team description: %s', Yaml::dump($team)));
-    } else if (0 === preg_match('/^[a-z][a-z0-9-]{3,29}(?<!-)$/', $team['name'])) {
-        fail(sprintf('Invalid team name: %s', $team['name']));
-    }
-}
-
 try {
     $azureApiClient = new AzureApiClient(
         getenv('AZURE_AD_APP_ID'),
@@ -90,7 +81,12 @@ $googleSuiteProvisioningApplicationId = getenv('AZURE_AD_GOOGLE_PROVISIONING_APP
 $appRoleId = getenv('AZURE_AD_GOOGLE_PROVISIONING_ROLE_ID');
 
 $runner = new Runner($azureApiClient, $githubApiClient, $naisDeploymentApiClient);
-$results = $runner->run($teams, $committerSamlId, $googleSuiteProvisioningApplicationId, $appRoleId);
+
+try {
+    $results = $runner->run($teams, $committerSamlId, $googleSuiteProvisioningApplicationId, $appRoleId);
+} catch (InvalidArgumentException $e) {
+    fail($e->getMessage());
+}
 
 (new ResultPrinter())->print($results);
 

--- a/src/AzureApiClient.php
+++ b/src/AzureApiClient.php
@@ -89,11 +89,12 @@ class AzureApiClient {
      * Create a group
      *
      * @param string $groupName The name of the group
+     * @param string $description The description of the group
      * @param string[] $owners List of users to be added as owners
      * @param string[] $members List of users to be added as members
      * @return AzureAdGroup
      */
-    public function createGroup(string $groupName, array $owners = [], array $members = []) : AzureAdGroup {
+    public function createGroup(string $groupName, string $description, array $owners = [], array $members = []) : AzureAdGroup {
         $prefixer = function(string $user) : string {
             return sprintf('%s/users/%s', rtrim($this->baseUri, '/'), $user);
         };
@@ -101,7 +102,7 @@ class AzureApiClient {
         $response = $this->httpClient->post('groups', [
             'json' => array_filter([
                 'displayName'        => $groupName,
-                'description'        => 'Team group created by https://github.com/navikt/teams',
+                'description'        => sprintf('%s (Team group created by https://github.com/navikt/teams)', $description),
                 'securityEnabled'    => true,
                 'mailEnabled'        => true,
                 'mailNickname'       => $groupName,

--- a/src/GitHubApiClient.php
+++ b/src/GitHubApiClient.php
@@ -52,15 +52,16 @@ class GitHubApiClient {
     /**
      * Create a new team
      *
-     * @param string $teamName The name of the team
+     * @param string $name The name of the team
+     * @param string $description The description of the team
      * @throws ClientException
      * @return GitHubTeam
      */
-    public function createTeam(string $teamName) : GitHubTeam {
+    public function createTeam(string $name, string $description) : GitHubTeam {
         $response = $this->httpClient->post('orgs/navikt/teams', [
             'json' => [
-                'name'        => $teamName,
-                'description' => 'Team created by https://github.com/navikt/teams',
+                'name'        => $name,
+                'description' => sprintf('%s (Team created by https://github.com/navikt/teams)', $description),
                 'privacy'     => 'closed'
             ],
         ]);

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -54,8 +54,10 @@ class Runner {
     ) : array {
         $result = [];
 
-        foreach ($teams as $teamName) {
-            $teamResult = new TeamResult($teamName);
+        foreach ($teams as $team) {
+            $teamName        = $team['name'];
+            $teamDescription = $team['description'];
+            $teamResult      = new TeamResult($teamName);
 
             $aadGroup = $this->azureApiClient->getGroupByName($teamName);
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -125,7 +125,7 @@ class Runner {
             }
 
             try {
-                $githubTeam = $this->githubApiClient->createTeam($teamName);
+                $githubTeam = $this->githubApiClient->createTeam($teamName, $teamDescription);
             } catch (ClientException $e) {
                 $result[$teamName] = $teamResult->fail(sprintf(
                     'Unable to create GitHub team "%s". Error message: %s',

--- a/tests/AzureApiClientTest.php
+++ b/tests/AzureApiClientTest.php
@@ -144,6 +144,7 @@ class AzureApiClientTest extends TestCase {
 
         $aadGroup = (new AzureApiClient('id', 'secret', $authClient, $httpClient))->createGroup(
             'group name',
+            'group description',
             ['Owner1@nav.no']
         );
 
@@ -156,6 +157,7 @@ class AzureApiClientTest extends TestCase {
         $body = json_decode($request->getBody()->getContents(), true);
 
         $this->assertSame('group name', $body['displayName'], 'Group name not correct');
+        $this->assertStringStartsWith('group description', $body['description'], 'Group description not correct');
         $this->assertSame('group name', $body['mailNickname'], 'Mail not correct');
         $this->assertArrayHasKey('owners@odata.bind', $body, 'Missing owners list');
         $this->assertSame(['https://graph.microsoft.com/beta/users/Owner1@nav.no'], $body['owners@odata.bind'], 'Invalid owners list');

--- a/tests/GitHubApiClientTest.php
+++ b/tests/GitHubApiClientTest.php
@@ -85,7 +85,7 @@ class GitHubApiClientTest extends TestCase {
             $clientHistory
         );
 
-        $githubTeam = (new GitHubApiClient('access-token', $httpClient))->createTeam('team-name');
+        $githubTeam = (new GitHubApiClient('access-token', $httpClient))->createTeam('team-name', 'team description');
 
         $this->assertInstanceOf(GitHubTeam::class, $githubTeam);
         $this->assertCount(1, $clientHistory, 'Expected one request');
@@ -97,6 +97,7 @@ class GitHubApiClientTest extends TestCase {
         $body = json_decode($request->getBody()->getContents(), true);
 
         $this->assertSame('team-name', $body['name'], 'Team name not correct');
+        $this->assertStringStartsWith('team description', $body['description'], 'Team description not correct');
     }
 
     /**

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -55,7 +55,7 @@ class RunnerTest extends TestCase {
             ->with('team-name')
             ->willReturn($this->createConfiguredMock(AzureAdGroup::class, ['getId' => 'group-id']));
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertSame('Group already exists in Azure AD with ID "group-id", skipping...', $teamResult->getMessage());
@@ -74,7 +74,7 @@ class RunnerTest extends TestCase {
             ->with('team-name')
             ->willReturn($this->createConfiguredMock(GitHubTeam::class, ['getId' => 123]));
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertSame('Team "team-name" (ID: 123) already exists on GitHub, skipping...', $teamResult->getMessage());
@@ -93,7 +93,7 @@ class RunnerTest extends TestCase {
             ->with('team-name', [$this->userObjectId], [$this->userObjectId])
             ->willThrowException($this->getClientException('error message'));
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertSame('Unable to create Azure AD group: "team-name". Error message: error message', $teamResult->getMessage());
@@ -119,7 +119,7 @@ class RunnerTest extends TestCase {
             ->with($aadGroup, $this->googleSuiteProvisioningApplicationId, $this->googleSuiteProvisioningApplicationRoleId)
             ->willThrowException($this->getClientException('error message'));
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertSame('Unable to add the Azure AD group to the Google Suite Provisioning application', $teamResult->getMessage());
@@ -146,7 +146,7 @@ class RunnerTest extends TestCase {
             ->with('team-name')
             ->willThrowException($this->getClientException('error message'));
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertSame('Unable to create GitHub team "team-name". Error message: error message', $teamResult->getMessage());
@@ -180,7 +180,7 @@ class RunnerTest extends TestCase {
             ->with($githubTeam, $aadGroup)
             ->willThrowException($this->getClientException('error message'));
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertSame('Unable to sync GitHub team and Azure AD group. Error message: error message', $teamResult->getMessage());
@@ -215,7 +215,7 @@ class RunnerTest extends TestCase {
             ->with('team-name')
             ->willThrowException($this->getClientException('error message'));
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertSame('Unable to create Nais deployment key. Error message: error message', $teamResult->getMessage());
@@ -245,7 +245,7 @@ class RunnerTest extends TestCase {
             ->with('team-name')
             ->willReturn($githubTeam);
 
-        $this->assertArrayHasKey('team-name', $result = $this->runRunner(['team-name']));
+        $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
         $teamResult = $result['team-name'];
         $this->assertSame('team-name', $teamResult->getTeamName());
         $this->assertTrue($teamResult->added());

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -144,7 +144,7 @@ class RunnerTest extends TestCase {
         $this->githubApiClient
             ->expects($this->once())
             ->method('createTeam')
-            ->with('team-name')
+            ->with('team-name', 'team description')
             ->willThrowException($this->getClientException('error message'));
 
         $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));
@@ -173,7 +173,7 @@ class RunnerTest extends TestCase {
         $this->githubApiClient
             ->expects($this->once())
             ->method('createTeam')
-            ->with('team-name')
+            ->with('team-name', 'team description')
             ->willReturn($githubTeam);
         $this->githubApiClient
             ->expects($this->once())
@@ -207,7 +207,7 @@ class RunnerTest extends TestCase {
         $this->githubApiClient
             ->expects($this->once())
             ->method('createTeam')
-            ->with('team-name')
+            ->with('team-name', 'team description')
             ->willReturn($githubTeam);
 
         $this->naisDeploymentApiClient
@@ -243,7 +243,7 @@ class RunnerTest extends TestCase {
         $this->githubApiClient
             ->expects($this->once())
             ->method('createTeam')
-            ->with('team-name')
+            ->with('team-name', 'team description')
             ->willReturn($githubTeam);
 
         $this->assertArrayHasKey('team-name', $result = $this->runRunner([['name' => 'team-name', 'description' => 'team description']]));


### PR DESCRIPTION
Currently the action does not use the supplied team description. It should use this description for the AAD group and GitHub team instead of the hard-coded one.