### PR TITLE
Add method for setting GitHub team description

### DIFF
--- a/src/GitHubApiClient.php
+++ b/src/GitHubApiClient.php
@@ -147,4 +147,33 @@ GQL;
 
         return true;
     }
+
+    /**
+     * Set team description
+     *
+     * @param string $slug The name slug
+     * @param string $description The description
+     * @return bool Returns true on success or false otherwise
+     */
+    public function setTeamDescription(string $slug, string $description) : bool {
+        try {
+            $response = $this->httpClient->get(sprintf('orgs/navikt/teams/%s', $slug));
+        } catch (ClientException $e) {
+            return false;
+        }
+
+        $teamId = json_decode($response->getBody()->getContents(), true)['id'];
+
+        try {
+            $this->httpClient->patch(sprintf('teams/%d', $teamId), [
+                'json' => [
+                    'description' => $description,
+                ],
+            ]);
+        } catch (ClientException $e) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -64,7 +64,7 @@ class Runner {
                 throw new InvalidArgumentException(sprintf('Missing team name: %s', Yaml::dump($team)));
             } else if (empty($team['description'])) {
                 throw new InvalidArgumentException(sprintf('Missing team description: %s', Yaml::dump($team)));
-            } else if (0 === preg_match('/^[a-z][a-z0-9-]{3,29}(?<!-)$/', $team['name'])) {
+            } else if (0 === preg_match('/^[a-z][a-z0-9-]{2,29}(?<!-)$/', $team['name'])) {
                 throw new InvalidArgumentException(sprintf('Invalid team name: %s', $team['name']));
             }
         }

--- a/tests/GitHubApiClientTest.php
+++ b/tests/GitHubApiClientTest.php
@@ -329,4 +329,45 @@ class GitHubApiClientTest extends TestCase {
 
         $this->assertSame('team description', $body['description'], 'Team description not correct');
     }
+
+    /**
+     * @covers ::setTeamDescription
+     */
+    public function testSetTeamDescriptionFailsWhenTeamDoesNotExist() : void {
+        $clientHistory = [];
+        $httpClient = $this->getMockClient(
+            [
+                new Response(404),
+            ],
+            $clientHistory
+        );
+
+        $this->assertFalse(
+            (new GitHubApiClient('access-token', $httpClient))->setTeamDescription('team-name', 'team description'),
+            'Expected method to fail'
+        );
+
+        $this->assertCount(1, $clientHistory, 'Expected one request');
+    }
+
+    /**
+     * @covers ::setTeamDescription
+     */
+    public function testSetTeamDescriptionFailsWhenPatchFails() : void {
+        $clientHistory = [];
+        $httpClient = $this->getMockClient(
+            [
+                new Response(200, [], '{"id": 123}'),
+                new Response(403),
+            ],
+            $clientHistory
+        );
+
+        $this->assertFalse(
+            (new GitHubApiClient('access-token', $httpClient))->setTeamDescription('team-name', 'team description'),
+            'Expected method to fail'
+        );
+
+        $this->assertCount(2, $clientHistory, 'Expected two requests');
+    }
 }


### PR DESCRIPTION
Add method for setting team description, and also fix the team length requirement. Resolves #23.