### PR TITLE
Add methods for fetching members and owners

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "test": "vendor/bin/phpunit",
         "test:coverage": "vendor/bin/phpunit --coverage-html build/coverage",
         "sa": "vendor/bin/phpstan analyse src -l max --no-progress",
-        "qa": [
+        "ci": [
+            "composer validate",
+            "@lint",
             "@sa",
             "@test"
         ]

--- a/src/AzureApiClient.php
+++ b/src/AzureApiClient.php
@@ -171,11 +171,11 @@ class AzureApiClient {
             '$top'    => 100
         ];
 
-        return array_map(function(array $group) : AzureAdGroup {
+        return array_filter(array_map(function(array $group) : ?AzureAdGroup {
             return $this->getGroupById($group['principalId']);
         }, array_filter($this->getPaginatedData($url, $query), function(array $group) : bool {
             return 'group' === strtolower($group['principalType']);
-        }));
+        })));
     }
 
     /**

--- a/src/AzureApiClient.php
+++ b/src/AzureApiClient.php
@@ -4,6 +4,9 @@ namespace NAV\Teams;
 use NAV\Teams\Models\AzureAdGroup;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
+use NAV\Teams\Exceptions\InvalidArgumentException;
+use NAV\Teams\Models\AzureAdGroupMember;
+use NAV\Teams\Models\AzureAdGroupOwner;
 
 class AzureApiClient {
     /**
@@ -162,26 +165,75 @@ class AzureApiClient {
      * @return AzureAdGroup[]
      */
     public function getEnterpriseAppGroups(string $applicationObjectId) : array {
-        $groups = [];
+        $url = sprintf('servicePrincipals/%s/appRoleAssignedTo', $applicationObjectId);
         $query = [
             '$select' => join(',', ['principalId', 'principalType']),
             '$top'    => 100
         ];
-        $nextLink = sprintf('servicePrincipals/%s/appRoleAssignedTo', $applicationObjectId);
 
-        while ($nextLink) {
-            $response = $this->httpClient->get($nextLink, ['query' => $query]);
-            $body = json_decode($response->getBody()->getContents(), true);
-            $groups = array_merge($groups, $body['value']);
-            $nextLink = $body['@odata.nextLink'] ?? null;
-            $query = []; // We only need the query for the first request as the nextLink will
-                         // inherit query params from the first request
-        }
-
-        return array_map(function(array $group) {
+        return array_map(function(array $group) : AzureAdGroup {
             return $this->getGroupById($group['principalId']);
-        }, array_filter($groups, function(array $group) : bool {
+        }, array_filter($this->getPaginatedData($url, $query), function(array $group) : bool {
             return 'group' === strtolower($group['principalType']);
         }));
+    }
+
+    /**
+     * Get all members in a group
+     *
+     * @param AzureAdGroup $group The group
+     * @return AzureAdGroupMember[] Returns an array of users
+     */
+    public function getGroupMembers(AzureAdGroup $group) : array {
+        return array_filter(array_map(function(array $member) : ?AzureAdGroupMember {
+            try {
+                return AzureAdGroupMember::fromArray($member);
+            } catch (InvalidArgumentException $e) {
+                return null;
+            }
+        }, $this->getPaginatedData(sprintf('groups/%s/members', $group->getId()), [
+            '$select' => join(',', ['id', 'displayName', 'mail']),
+            '$top' => 100
+        ])));
+    }
+
+    /**
+     * Get all owners of a group
+     *
+     * @param AzureAdGroup $group The group
+     * @return AzureAdGroupOwner[] Returns an array of users
+     */
+    public function getGroupOwners(AzureAdGroup $group) : array {
+        return array_filter(array_map(function(array $member) : ?AzureAdGroupOwner {
+            try {
+                return AzureAdGroupOwner::fromArray($member);
+            } catch (InvalidArgumentException $e) {
+                return null;
+            }
+        }, $this->getPaginatedData(sprintf('groups/%s/owners', $group->getId()), [
+            '$select' => join(',', ['id', 'displayName', 'mail']),
+            '$top' => 100
+        ])));
+    }
+
+    /**
+     * Get paginated data from the API
+     *
+     * @param string $url The URL to fetch
+     * @param array $query Query parameters
+     * @return array
+     */
+    private function getPaginatedData(string $url, array $query = []) : array {
+        $entries = [];
+
+        while ($url) {
+            $response = $this->httpClient->get($url, ['query' => $query]);
+            $body = json_decode($response->getBody()->getContents(), true);
+            $entries = array_merge($entries, $body['value']);
+            $url = $body['@odata.nextLink'] ?? null;
+            $query = []; // Only need this for the first request
+        }
+
+        return $entries;
     }
 }

--- a/src/Models/AzureAdGroupMember.php
+++ b/src/Models/AzureAdGroupMember.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+namespace NAV\Teams\Models;
+
+use NAV\Teams\Exceptions\InvalidArgumentException;
+
+class AzureAdGroupMember {
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $displayName;
+
+    /**
+     * @var string
+     */
+    private $mail;
+
+    /**
+     * Class constructor
+     *
+     * @param string $id The ID of the group
+     * @param string $displayName The display name of the group
+     * @param string $mail The mail address for the group
+     */
+    public function __construct(string $id, string $displayName, string $mail) {
+        $this->id          = $id;
+        $this->displayName = $displayName;
+        $this->mail        = $mail;
+    }
+
+    /**
+     * Get the ID
+     *
+     * @return string
+     */
+    public function getId() : string {
+        return $this->id;
+    }
+
+    /**
+     * Get the display name
+     *
+     * @return string
+     */
+    public function getDisplayName() : string {
+        return $this->displayName;
+    }
+
+    /**
+     * Get the mail
+     *
+     * @return string
+     */
+    public function getMail() : string {
+        return $this->mail;
+    }
+
+    /**
+     * Create an instance from an array
+     *
+     * @param array $data
+     * @throws InvalidArgumentException
+     * @return static
+     */
+    public static function fromArray(array $data) : self {
+        foreach (['id', 'displayName', 'mail'] as $required) {
+            if (empty($data[$required])) {
+                throw new InvalidArgumentException(sprintf('Missing data element: %s', $required));
+            }
+        }
+
+        return new static(
+            $data['id'],
+            $data['displayName'],
+            $data['mail']
+        );
+    }
+}

--- a/src/Models/AzureAdGroupOwner.php
+++ b/src/Models/AzureAdGroupOwner.php
@@ -1,0 +1,4 @@
+<?php declare(strict_types=1);
+namespace NAV\Teams\Models;
+
+class AzureAdGroupOwner extends AzureAdGroupMember {}

--- a/tests/Models/AzureAdGroupMemberTest.php
+++ b/tests/Models/AzureAdGroupMemberTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+namespace NAV\Teams\Models;
+
+use NAV\Teams\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass NAV\Teams\Models\AzureAdGroupMember
+ */
+class AzureAdGroupMemberTest extends TestCase {
+    public function getCreationData() : array {
+        return [
+            'all elements present' => [
+                'some-id',
+                'some name',
+                'mail@nav.no'
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::fromArray
+     * @covers ::getId
+     * @covers ::getDisplayName
+     * @covers ::getMail
+     * @covers ::__construct
+     * @dataProvider getCreationData
+     */
+    public function testCanCreateFromArray(string $id, string $displayName, string $mail) : void {
+        $group = AzureAdGroupMember::fromArray([
+            'id'          => $id,
+            'displayName' => $displayName,
+            'mail'        => $mail,
+        ]);
+        $this->assertInstanceOf(AzureAdGroupMember::class, $group);
+        $this->assertSame($id, $group->getId());
+        $this->assertSame($displayName, $group->getDisplayName());
+        $this->assertSame($mail, $group->getMail());
+    }
+
+    public function getInvalidData() : array {
+        return [
+            'missing id' => [
+                [
+                    'displayName' => 'name',
+                ],
+                'Missing data element: id'
+            ],
+            'missing display name' => [
+                [
+                    'id' => 'some-id',
+                ],
+                'Missing data element: displayName'
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::fromArray
+     * @dataProvider getInvalidData
+     */
+    public function testCanValidateInput(array $data, string $errorMessage) : void {
+        $this->expectExceptionObject(new InvalidArgumentException($errorMessage));
+        AzureAdGroupMember::fromArray($data);
+    }
+}

--- a/tests/Models/AzureAdGroupOwnerTest.php
+++ b/tests/Models/AzureAdGroupOwnerTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+namespace NAV\Teams\Models;
+
+use NAV\Teams\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass NAV\Teams\Models\AzureAdGroupOwner
+ */
+class AzureAdGroupOwnerTest extends TestCase {
+    public function getCreationData() : array {
+        return [
+            'all elements present' => [
+                'some-id',
+                'some name',
+                'mail@nav.no'
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::fromArray
+     * @covers ::getId
+     * @covers ::getDisplayName
+     * @covers ::getMail
+     * @covers ::__construct
+     * @dataProvider getCreationData
+     */
+    public function testCanCreateFromArray(string $id, string $displayName, string $mail) : void {
+        $group = AzureAdGroupOwner::fromArray([
+            'id'          => $id,
+            'displayName' => $displayName,
+            'mail'        => $mail,
+        ]);
+        $this->assertInstanceOf(AzureAdGroupOwner::class, $group);
+        $this->assertSame($id, $group->getId());
+        $this->assertSame($displayName, $group->getDisplayName());
+        $this->assertSame($mail, $group->getMail());
+    }
+
+    public function getInvalidData() : array {
+        return [
+            'missing id' => [
+                [
+                    'displayName' => 'name',
+                ],
+                'Missing data element: id'
+            ],
+            'missing display name' => [
+                [
+                    'id' => 'some-id',
+                ],
+                'Missing data element: displayName'
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::fromArray
+     * @dataProvider getInvalidData
+     */
+    public function testCanValidateInput(array $data, string $errorMessage) : void {
+        $this->expectExceptionObject(new InvalidArgumentException($errorMessage));
+        AzureAdGroupOwner::fromArray($data);
+    }
+}


### PR DESCRIPTION
Includes two simple models for members and owners, with the following attributes:

- `id`: Object ID of the user
- `displayName`: Name in `Sur, Given`-format
- `mail`: Email address

Resolves #26 
